### PR TITLE
threadlocal StringBuilder benchmarks

### DIFF
--- a/src/test/java/org/jsoup/internal/StringUtilTest.java
+++ b/src/test/java/org/jsoup/internal/StringUtilTest.java
@@ -104,8 +104,10 @@ public class StringUtilTest {
         assertEquals("ftp://example.com/one/two.c", resolve("ftp://example.com/one/", "two.c"));
     }
 
-    @Test public void cachedStringBuilderPerf() throws InterruptedException {
-        int nthreads = 32;
+    private void cachedStringBuilderPerfInner(int nthreads) throws InterruptedException {
+        System.out.println("------------------");
+        System.out.println("threads = " + nthreads);
+        System.out.println("------------------");
         ExecutorService exec = Executors.newFixedThreadPool(nthreads);
         for (int t = 0; t < nthreads; t++) {
             exec.execute(() -> {
@@ -145,5 +147,10 @@ public class StringUtilTest {
         }
         exec.shutdown();
         exec.awaitTermination(60, TimeUnit.SECONDS);
+    }
+
+    @Test public void cachedStringBuilderPerf() throws InterruptedException {
+        cachedStringBuilderPerfInner(8);
+        cachedStringBuilderPerfInner(32);
     }
 }


### PR DESCRIPTION
## Environment
machine: GCP n2d-highcpu-8 (8cpu)
OS: CentOS Linux release 7.8.2003 (Core)

## Test Result (the former elapsed times are current implementation (w/ synchronized), the latter are w/ ThreadLocal)
```
mvn test -Dtest="StringUtilTest#cachedStringBuilderPerf"
[INFO] Running org.jsoup.internal.StringUtilTest
------------------
threads = 8
------------------
elapsed: 1662ms
elapsed: 1577ms
elapsed: 1742ms
elapsed: 1728ms
elapsed: 1577ms
elapsed: 1632ms
elapsed: 1786ms
elapsed: 1336ms
------------------
elapsed: 179ms
elapsed: 163ms
elapsed: 176ms
elapsed: 143ms
elapsed: 166ms
elapsed: 154ms
elapsed: 168ms
elapsed: 159ms
------------------
threads = 32
------------------
elapsed: 6027ms
elapsed: 6171ms
elapsed: 5924ms
elapsed: 6073ms
elapsed: 6141ms
elapsed: 5953ms
elapsed: 6208ms
elapsed: 5861ms
elapsed: 6208ms
elapsed: 6093ms
elapsed: 6376ms
elapsed: 6141ms
elapsed: 6222ms
elapsed: 5980ms
elapsed: 5606ms
elapsed: 6206ms
elapsed: 5751ms
elapsed: 6324ms
elapsed: 6272ms
elapsed: 6291ms
elapsed: 6012ms
elapsed: 6248ms
elapsed: 5971ms
elapsed: 6326ms
elapsed: 5908ms
elapsed: 6056ms
elapsed: 5658ms
elapsed: 6343ms
elapsed: 5795ms
elapsed: 5886ms
elapsed: 5881ms
elapsed: 5945ms
------------------
elapsed: 167ms
elapsed: 47ms
elapsed: 139ms
elapsed: 143ms
elapsed: 187ms
elapsed: 69ms
elapsed: 205ms
elapsed: 159ms
elapsed: 266ms
elapsed: 48ms
elapsed: 55ms
elapsed: 291ms
elapsed: 117ms
elapsed: 70ms
elapsed: 125ms
elapsed: 218ms
elapsed: 315ms
elapsed: 259ms
elapsed: 118ms
elapsed: 80ms
elapsed: 81ms
elapsed: 67ms
elapsed: 58ms
elapsed: 145ms
elapsed: 420ms
elapsed: 95ms
elapsed: 67ms
elapsed: 126ms
elapsed: 87ms
elapsed: 63ms
elapsed: 77ms
elapsed: 41ms
```